### PR TITLE
issues/15: Disable get-installed-path

### DIFF
--- a/test.json
+++ b/test.json
@@ -2327,7 +2327,8 @@
     "name": "get-installed-path",
     "repo": "https://github.com/tunnckoCore/get-installed-path",
     "description": "Get the installation path of the given package if it is installed globally or locally.",
-    "dependents": 3
+    "dependents": 3,
+    "disable": true
   },
   {
     "name": "anvil-connect-jwt",


### PR DESCRIPTION
https://github.com/standard/standard-packages/issues/15

The target project fails for multiple comma-dangle issues. These issues are correct, there are dangling commas in the test file per the current rules.