### PR TITLE
Disable express-restify-mongoose

### DIFF
--- a/all.json
+++ b/all.json
@@ -9153,7 +9153,8 @@
     "name": "express-restify-mongoose",
     "repo": "https://github.com/florianholzapfel/express-restify-mongoose",
     "description": "Easily create a flexible REST interface for mongoose models",
-    "dependents": 7
+    "dependents": 7,
+    "disable": true
   },
   {
     "name": "fail-nicely",

--- a/test.json
+++ b/test.json
@@ -1798,7 +1798,8 @@
     "name": "express-restify-mongoose",
     "repo": "https://github.com/florianholzapfel/express-restify-mongoose",
     "description": "Easily create a flexible REST interface for mongoose models",
-    "dependents": 4
+    "dependents": 4,
+    "disable": true
   },
   {
     "name": "couchdb-push",


### PR DESCRIPTION
It no longer uses standard, see https://github.com/florianholzapfel/express-restify-mongoose/commit/a133e8e375995150a65be61d01f1eec4c8344e5c#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L61

Fixes https://github.com/standard/standard-packages/issues/19