### PR TITLE
Disable make-error

### DIFF
--- a/test.json
+++ b/test.json
@@ -600,7 +600,8 @@
     "name": "make-error",
     "repo": "https://github.com/julien-f/js-make-error",
     "description": "Make your own error types!",
-    "dependents": 19
+    "dependents": 19,
+    "disable": true
   },
   {
     "name": "multistream",


### PR DESCRIPTION
No longer uses pure standard: https://github.com/JsCommunity/make-error/commit/1612c34e402ce89d871d1af4a95ccea0eb4aa07d