### PR TITLE
Replicate npm registry to replace skimdb.npmjs.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-rawdata.json
 node_modules

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ packages.forEach(pkg => {
 
 ## Contribute
 
-To update the data in `all.json` run:
+To update the data in `all.json`, install [CouchDB](https://couchdb.apache.org), create an `npm_registry` database, and run:
 
 ```bash
-npm run fetch && npm run update
+npm run replicate && npm run update
 ```
 
-:warning: `npm run fetch` will download and save a 1 GB+ file named `tmp/rawdata.json`
+:warning: `npm run replicate` will [replicate](https://docs.couchdb.org/en/stable/replication/intro.html) a 10 GB+ database
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chalk": "^2.3.0",
     "event-stream": "4.0.1",
     "github-url-to-object": "^4.0.2",
+    "nano": "^8.1.0",
     "pad-left": "^2.0.0",
     "run-series": "^1.1.4",
     "simple-get": "^3.0.0",
@@ -53,7 +54,7 @@
     "url": "git://github.com/standard/standard-packages.git"
   },
   "scripts": {
-    "fetch": "mkdir -p tmp && curl https://skimdb.npmjs.com/registry/_design/scratch/_view/byField > tmp/rawdata.json",
+    "replicate": "node tools/replicate.js",
     "test": "standard && node -e \"require('./')\"",
     "test-full": "npm test && node test/full.js",
     "update": "node tools/update.js"

--- a/tools/replicate.js
+++ b/tools/replicate.js
@@ -1,0 +1,3 @@
+var nano = require('nano')('http://localhost:5984')
+
+nano.db.replicate('https://replicate.npmjs.com', 'npm_registry')


### PR DESCRIPTION
Since skimdb.npmjs.com is deprecated, the current `npm run fetch` command just creates an empty `rawdata.json`. As a replacement, we can replicate the entire npm registry database from replicate.npmjs.com. See [npm/registry-follower-tutorial](https://github.com/npm/registry-follower-tutorial) for more information on this approach.

`npm run replicate` (replacing `npm run fetch`) will now [replicate](https://docs.couchdb.org/en/stable/replication/intro.html) the npm registry to the local `npm_registry` CouchDB database. This will take some while on the first run, however, it will be significantly faster to catch up on the latest changes on subsequent runs.

Since the underlying data is quite similar to the previous `rawdata.json`, I only had to make minor changes to `tools/update.js`. The actual processing and generation of `all.json` should therefore be the same as before.

Closes #27.